### PR TITLE
[SSLNTV-3] Add support for TLS 1.3

### DIFF
--- a/libwfssl/include/wfssl.h
+++ b/libwfssl/include/wfssl.h
@@ -197,6 +197,7 @@ typedef  unsigned __int64   uint64_t;
 #define SSL_OP_NO_SSLv2                                 0x01000000L
 #define SSL_OP_NO_SSLv3                                 0x02000000L
 #define SSL_OP_NO_TLSv1                                 0x04000000L
+#define SSL_OP_NO_TLSv1_3                               0x20000000L
 #define SSL_OP_NO_TLSv1_2                               0x08000000L
 #define SSL_OP_NO_TLSv1_1                               0x10000000L
 #define SSL_OP_SINGLE_ECDH_USE                          0x00080000L
@@ -280,6 +281,8 @@ typedef  unsigned __int64   uint64_t;
 #define SSL_PROTOCOL_TLSV1      (1<<2)
 #define SSL_PROTOCOL_TLSV1_1    (1<<3)
 #define SSL_PROTOCOL_TLSV1_2    (1<<4)
+#define SSL_PROTOCOL_TLSV1_3    (1<<5)
+#define SSL_PROTOCOL_ALL (SSL_PROTOCOL_TLSV1|SSL_PROTOCOL_TLSV1_1|SSL_PROTOCOL_TLSV1_2|SSL_PROTOCOL_TLSV1_3)
 
 #define SSL_MODE_CLIENT         (0)
 #define SSL_MODE_SERVER         (1)
@@ -464,6 +467,7 @@ typedef struct {
     int             next_selector_failure_behavior;
     /* End add from netty-tcnative */
     jobject session_context;
+    jobject client_session_context;
 } tcn_ssl_ctxt_t;
 
 
@@ -528,6 +532,7 @@ typedef struct {
     void (*SSL_CTX_set_alpn_select_cb)(SSL_CTX *ctx, int (*cb) (SSL *ssl, const unsigned char **out, unsigned char *outlen, const unsigned char *in, unsigned int inlen, void *arg), void *arg);
     void (*SSL_CTX_set_cert_verify_callback)(SSL_CTX *ctx, int (*cb) (X509_STORE_CTX *, void *), void *arg);
     int (*SSL_CTX_set_cipher_list)(SSL_CTX *, const char *str);
+    int (*SSL_CTX_set_ciphersuites)(SSL_CTX *, const char *str);
     int (*SSL_CTX_set_default_verify_paths)(SSL_CTX *ctx);
     int (*SSL_CTX_set_session_id_context)(SSL_CTX *ctx, const unsigned char *sid_ctx, unsigned int sid_ctx_len);
     long (*SSL_CTX_set_timeout)(SSL_CTX *ctx, long t);
@@ -565,6 +570,7 @@ typedef struct {
     void (*SSL_set_accept_state)(SSL *s);
     void (*SSL_set_bio)(SSL *s, BIO *rbio, BIO *wbio);
     int (*SSL_set_cipher_list)(SSL *s, const char *str);
+    int (*SSL_set_ciphersuites)(SSL *s, const char *str);
     void (*SSL_set_connect_state)(SSL *s);
     void (*SSL_set_verify)(SSL *s, int mode, int (*callback) (int ok, X509_STORE_CTX *ctx));
     void (*SSL_set_verify_result)(SSL *ssl, long v);
@@ -592,6 +598,8 @@ typedef struct {
     int (*SSL_set_max_proto_version)(SSL *ssl, int version);
     int (*SSL_get_min_proto_version)(SSL *ssl);
     int (*SSL_get_max_proto_version)(SSL *ssl);
+    long (*SSL_SESSION_set_timeout)(SSL_SESSION *s, long timeout);
+    int (*SSL_session_reused)(SSL *ssl);
 } ssl_dynamic_methods;
 
 typedef struct {
@@ -684,6 +692,7 @@ tcn_ssl_conn_t *SSL_get_app_data1(const SSL *ssl);
 tcn_ssl_ctxt_t *SSL_get_app_data2(const SSL *ssl);
 tcn_ssl_ctxt_t *SSL_CTX_get_app_data1(const SSL_CTX *ssl);
 void setup_session_context(JNIEnv *e, tcn_ssl_ctxt_t *c);
+void setup_client_session_context(JNIEnv *e, tcn_ssl_ctxt_t *c);
 long set_options_internal(SSL *ssl, long options);
 long set_CTX_options_internal(SSL_CTX *ctx, long options);
 /*thread setup function*/

--- a/libwfssl/src/session.c
+++ b/libwfssl/src/session.c
@@ -85,7 +85,7 @@ WF_OPENSSL(jlong, setSessionCacheSize)(JNIEnv *e, jobject o, jlong ctx, jlong si
 
     /*  Also allow size of 0 which is unlimited */
     if (size >= 0) {
-      ssl_methods.SSL_CTX_ctrl(c->ctx,SSL_CTRL_SET_SESS_CACHE_MODE,SSL_SESS_CACHE_SERVER,NULL);
+      ssl_methods.SSL_CTX_ctrl(c->ctx,SSL_CTRL_SET_SESS_CACHE_MODE,SSL_SESS_CACHE_BOTH,NULL);
       rv = ssl_methods.SSL_CTX_ctrl(c->ctx,SSL_CTRL_SET_SESS_CACHE_SIZE,size,NULL);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
     <packaging>pom</packaging>
 
     <properties>
+        <jdk.min.version>11</jdk.min.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.org.wildfly.checkstyle>1.0.8.Final</version.org.wildfly.checkstyle>
 


### PR DESCRIPTION
OpenSSL 1.1.1 added support for TLS 1.3. This PR adds support for TLS 1.3 to the WildFly OpenSSL provider. 

https://issues.redhat.com/browse/SSLNTV-3
https://issues.redhat.com/browse/SSLNTV-2