### PR TITLE
[SSLNTV-6] Allow JDK 8 to be used for linux-i386, linux-rhel6-i386, solaris-sparcv9, and solaris-x86_64

### DIFF
--- a/linux-i386/pom.xml
+++ b/linux-i386/pom.xml
@@ -30,6 +30,10 @@
     <artifactId>wildfly-openssl-linux-i386</artifactId>
     <version>2.2.0.CR1-SNAPSHOT</version>
 
+    <properties>
+      <jdk.min.version>1.8</jdk.min.version>
+    </properties>
+
     <packaging>jar</packaging>
 
     <build>

--- a/linux-rhel6-i386/pom.xml
+++ b/linux-rhel6-i386/pom.xml
@@ -30,6 +30,10 @@
     <artifactId>wildfly-openssl-linux-rhel6-i386</artifactId>
     <version>2.2.0.CR1-SNAPSHOT</version>
 
+    <properties>
+      <jdk.min.version>1.8</jdk.min.version>
+    </properties>
+
     <packaging>jar</packaging>
 
     <build>

--- a/solaris-sparcv9/pom.xml
+++ b/solaris-sparcv9/pom.xml
@@ -30,6 +30,10 @@
     <artifactId>wildfly-openssl-solaris-sparcv9</artifactId>
     <version>2.2.0.CR1-SNAPSHOT</version>
 
+    <properties>
+      <jdk.min.version>1.8</jdk.min.version>
+    </properties>
+
     <packaging>jar</packaging>
 
     <build>

--- a/solaris-x86_64/pom.xml
+++ b/solaris-x86_64/pom.xml
@@ -30,6 +30,10 @@
     <artifactId>wildfly-openssl-solaris-x86_64</artifactId>
     <version>2.2.0.CR1-SNAPSHOT</version>
 
+    <properties>
+      <jdk.min.version>1.8</jdk.min.version>
+    </properties>
+
     <packaging>jar</packaging>
 
     <build>


### PR DESCRIPTION
https://issues.redhat.com/browse/SSLNTV-6