### PR TITLE
[SSLNTV-11] Add a new GitHub workflow to trigger native builds for pull requests and new tags and also archive the built native artifacts for new tags

### DIFF
--- a/.github/workflows/build-natives.yaml
+++ b/.github/workflows/build-natives.yaml
@@ -1,0 +1,57 @@
+name: Build Natives
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+        - os: windows-latest
+          vcvars: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Maven Version Info
+        run: mvn -version
+      - if: matrix.os != 'windows-latest'
+        name: OpenSSL Library Version Info
+        run: openssl version -v
+      - if: matrix.os == 'windows-latest'
+        name: Install Full OpenSSL Library
+        run: |
+          choco install --no-progress openssl
+      - if: matrix.os != 'windows-latest'
+        name: Build with Maven
+        run: mvn -B package --file pom.xml
+      - if: matrix.os == 'windows-latest'
+        name: Build with Microsoft Visual Studio native tools command prompt and Maven
+        env:
+          VCVARS: ${{ matrix.vcvars }}
+        shell: cmd
+        run: |
+          call "%VCVARS%"
+          mvn -B package --file pom.xml
+      - if: ${{ github.event_name == 'push' }}
+        name: Archive the built native artifacts if this is a tag
+        uses: actions/upload-artifact@v2
+        with:
+          name: built-natives
+          path: |
+            **/target/**.jar


### PR DESCRIPTION
https://issues.redhat.com/browse/SSLNTV-11

This allows the Linux, Windows, and macOS natives to get built automatically when a PR is submitted and when a new tag is pushed. The built native artifacts will also be archived for new tags so we can download them and then continue with the rest of the release process.