### PR TITLE
[SSLNTV-14] add support for macos aarch64 a.k.a Apple Silicon

### DIFF
--- a/macosx-aarch64/Makefile
+++ b/macosx-aarch64/Makefile
@@ -1,0 +1,17 @@
+CC = cc
+SRC = alpn.c clientcert.c options.c session.c ssl.c threads.c util.c
+OBJ = $(patsubst %.c, target/%.o, $(SRC))
+
+default: target/classes/macosx-aarch64/libwfssl.dylib
+
+clean:
+	rm -rf target
+
+target/classes/macosx-aarch64:
+	mkdir -p target/classes/macosx-aarch64
+
+target/%.o : ../libwfssl/src/%.c target/classes/macosx-aarch64
+	$(CC) $(CFLAGS) -mmacosx-version-min=11.0 -target arm64-apple-macos11.0 -Werror -Wall -Wmissing-prototypes -Wstrict-prototypes -Wmissing-declarations -Wpointer-arith -std=c89 -Wdeclaration-after-statement -Wformat -Wformat-security -Wunused -Wno-unknown-pragmas -c $< -o $@ -I../libwfssl/include -I${JAVA_HOME}/include -I${JAVA_HOME}/include/darwin
+
+target/classes/macosx-aarch64/libwfssl.dylib: $(OBJ)
+	$(CC) $(CFLAGS) -mmacosx-version-min=11.0 -target arm64-apple-macos11.0 -dynamiclib $(OBJ) -o $@ $(LDFLAGS)

--- a/macosx-aarch64/pom.xml
+++ b/macosx-aarch64/pom.xml
@@ -1,0 +1,82 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.openssl</groupId>
+        <artifactId>wildfly-openssl-natives-parent</artifactId>
+        <version>2.2.0.CR1-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <groupId>org.wildfly.openssl</groupId>
+    <artifactId>wildfly-openssl-macosx-aarch64</artifactId>
+    <version>2.2.0.CR1-SNAPSHOT</version>
+
+    <packaging>jar</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <executable>make</executable>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <profiles>
+        <profile>
+            <id>parent-release</id>
+            <activation>
+                <property>
+                    <name>parent-release</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-deploy-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/macosx-x86_64/Makefile
+++ b/macosx-x86_64/Makefile
@@ -11,7 +11,7 @@ target/classes/macosx-x86_64:
 	mkdir -p target/classes/macosx-x86_64
 
 target/%.o : ../libwfssl/src/%.c target/classes/macosx-x86_64
-	$(CC) $(CFLAGS) -Werror -Wall -Wmissing-prototypes -Wstrict-prototypes -Wmissing-declarations -Wpointer-arith -std=c89 -Wdeclaration-after-statement -Wformat -Wformat-security -Wunused -Wno-unknown-pragmas -c $< -o $@ -I../libwfssl/include -I${JAVA_HOME}/include -I${JAVA_HOME}/include/darwin
+	$(CC) $(CFLAGS) -arch x86_64 -Werror -Wall -Wmissing-prototypes -Wstrict-prototypes -Wmissing-declarations -Wpointer-arith -std=c89 -Wdeclaration-after-statement -Wformat -Wformat-security -Wunused -Wno-unknown-pragmas -c $< -o $@ -I../libwfssl/include -I${JAVA_HOME}/include -I${JAVA_HOME}/include/darwin
 
 target/classes/macosx-x86_64/libwfssl.dylib: $(OBJ)
-	$(CC) $(CFLAGS) -dynamiclib $(OBJ) -o $@ $(LDFLAGS)
+	$(CC) $(CFLAGS) -arch x86_64 -dynamiclib $(OBJ) -o $@ $(LDFLAGS)

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,7 @@
             </activation>
             <modules>
                 <module>macosx-x86_64</module>
+                <module>macosx-aarch64</module>
             </modules>
         </profile>
         <profile>


### PR DESCRIPTION
Added an Apple Silicon target macosx-aarch64 so that the next wildfly-as for homebrew is able to be installed on an M1