### PR TITLE
[SSLNTV-24] Segmentation fault in X509_STORE_add_lookup

### DIFF
--- a/libwfssl/src/clientcert.c
+++ b/libwfssl/src/clientcert.c
@@ -111,15 +111,6 @@ WF_OPENSSL(void, setSSLVerify)(JNIEnv *e, jobject o, jlong ssl, jint level, jint
     if ((c->verify_mode == SSL_CVERIFY_OPTIONAL) ||
         (c->verify_mode == SSL_CVERIFY_OPTIONAL_NO_CA))
         verify |= SSL_VERIFY_PEER;
-    if (!c->store) {
-        if (ssl_methods.SSL_CTX_set_default_verify_paths(c->ctx)) {
-            c->store = ssl_methods.SSL_CTX_get_cert_store(c->ctx);
-            crypto_methods.X509_STORE_set_flags(c->store, 0);
-        }
-        else {
-            /* XXX: See if this is fatal */
-        }
-    }
 
     ssl_methods.SSL_set_verify(ssl_, verify, SSL_callback_SSL_verify);
 }

--- a/libwfssl/src/ssl.c
+++ b/libwfssl/src/ssl.c
@@ -690,6 +690,16 @@ WF_OPENSSL(jlong, makeSSLContext)(JNIEnv *e, jobject o, jint protocol, jint mode
         clazz = (*e)->FindClass(e, "[B");
         byteArrayClass = (jclass) (*e)->NewGlobalRef(e, clazz);
 
+        /* The store is also initialized with the SSL context cos doing it in
+         * setSSLVerify as before can trigger a crash if multi-threading
+         */
+        if (ssl_methods.SSL_CTX_set_default_verify_paths(c->ctx)) {
+            c->store = ssl_methods.SSL_CTX_get_cert_store(c->ctx);
+            crypto_methods.X509_STORE_set_flags(c->store, 0);
+        } else {
+            /* XXX: See if this is fatal */
+        }
+
         setupDH(e, ctx);
         return P2J(c);
     init_failed:


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/SSLNTV-24

As commented in the JIRA the `SSL_CTX_set_default_verify_paths` was moved from `setSSLVerify` to `makeSSLContext`. This way the store is initialized when the ssl context is created avoiding any race. This method is only executed 4 times (one for each openssl provider).

No tests added to the java part because the crash was only when multiple threads accessed the `setSSLVerify` for the first time in the context. There are tests that do multi-thread access but they were executed after the `OpenSSLCOntextSPI` was already being used and initialized and the issue was not detected.