### PR TITLE
[SSLNTV-32] Add a new GitHub workflow to trigger native builds for pull requests and tags for Windows

### DIFF
--- a/.github/workflows/build-natives.yaml
+++ b/.github/workflows/build-natives.yaml
@@ -1,0 +1,57 @@
+name: Build Natives
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+        - os: windows-latest
+          vcvars: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Maven Version Info
+        run: mvn -version
+      - if: matrix.os != 'windows-latest'
+        name: OpenSSL Library Version Info
+        run: openssl version -v
+      - if: matrix.os == 'windows-latest'
+        name: Install Full OpenSSL Library
+        run: |
+          choco install --no-progress openssl
+      - if: matrix.os != 'windows-latest'
+        name: Build with Maven
+        run: mvn -B package --file pom.xml
+      - if: matrix.os == 'windows-latest'
+        name: Build with Microsoft Visual Studio native tools command prompt and Maven
+        env:
+          VCVARS: ${{ matrix.vcvars }}
+        shell: cmd
+        run: |
+          call "%VCVARS%"
+          mvn -B package --file pom.xml
+      - if: ${{ github.event_name == 'push' }}
+        name: Archive the built native artifacts if this is a tag
+        uses: actions/upload-artifact@v2
+        with:
+          name: built-natives
+          path: |
+            **/target/**.jar

--- a/.github/workflows/build-natives.yaml
+++ b/.github/workflows/build-natives.yaml
@@ -2,7 +2,7 @@ name: Build Natives
 on:
   pull_request:
     branches:
-      - master
+      - main
   push:
     tags:
       - '*'
@@ -14,8 +14,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         include:
-        - os: windows-latest
-          vcvars: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat
+          - os: windows-latest
+            vcvars: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11
@@ -36,17 +36,21 @@ jobs:
       - if: matrix.os == 'windows-latest'
         name: Install Full OpenSSL Library
         run: |
-          choco install --no-progress openssl
+          vcpkg install openssl:x64-windows
       - if: matrix.os != 'windows-latest'
         name: Build with Maven
-        run: mvn -B package --file pom.xml
+        run: |
+          openssl version -v
+          mvn -B package --file pom.xml
       - if: matrix.os == 'windows-latest'
         name: Build with Microsoft Visual Studio native tools command prompt and Maven
         env:
           VCVARS: ${{ matrix.vcvars }}
         shell: cmd
         run: |
-          call "%VCVARS%"
+          call "%VCVARS%" x64          
+          set PATH=C:\vcpkg\installed\x64-windows\tools\openssl;%PATH%
+          openssl version -v
           mvn -B package --file pom.xml
       - if: ${{ github.event_name == 'push' }}
         name: Archive the built native artifacts if this is a tag

--- a/.github/workflows/build-natives.yaml
+++ b/.github/workflows/build-natives.yaml
@@ -15,7 +15,7 @@ jobs:
         working-directory: main
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [windows-latest]
         include:
           - os: windows-latest
             vcvars: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat

--- a/.github/workflows/build-natives.yaml
+++ b/.github/workflows/build-natives.yaml
@@ -10,6 +10,9 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: main
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
@@ -18,10 +21,17 @@ jobs:
             vcvars: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat
     steps:
       - uses: actions/checkout@v2
+        with:
+          path: main
       - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
           java-version: 11
+      - name: Checkout wildfly-openssl for test purposes
+        uses: actions/checkout@v2
+        with:
+          repository: wildfly-security/wildfly-openssl
+          path: wildfly-openssl
       - name: Cache Maven packages
         uses: actions/cache@v2
         with:
@@ -48,10 +58,23 @@ jobs:
           VCVARS: ${{ matrix.vcvars }}
         shell: cmd
         run: |
-          call "%VCVARS%" x64          
+          call "%VCVARS%" x64
           set PATH=C:\vcpkg\installed\x64-windows\tools\openssl;%PATH%
           openssl version -v
-          mvn -B package --file pom.xml
+          mvn -B install --file pom.xml
+      - if: matrix.os == 'windows-latest'
+        name: Run tests with the built Windows native
+        env:
+          VCVARS: ${{ matrix.vcvars }}
+        working-directory: wildfly-openssl
+        shell: cmd
+        run: |
+          call "%VCVARS%" x64
+          set PATH=C:\vcpkg\installed\x64-windows\tools\openssl;%PATH%
+          openssl version -v
+          for /f "tokens=3 delims=<> skip=1" %%v in ('findstr "<version>" ..\main\pom.xml') do set WILDFLY_OPENSSL_NATIVES_VERSION=%%v
+          echo Running tests with WildFly OpenSSL Natives %WILDFLY_OPENSSL_NATIVES_VERSION%
+          mvn -B verify --file pom.xml -Dorg.wildfly.openssl.path="C:\vcpkg\installed\x64-windows\tools\openssl" -Dversion.org.wildfly.openssl.natives=%WILDFLY_OPENSSL_NATIVES_VERSION%
       - if: ${{ github.event_name == 'push' }}
         name: Archive the built native artifacts if this is a tag
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
https://issues.redhat.com/browse/SSLNTV-32

This PR ensures that we can now build the Windows native using the latest version of OpenSSL 3 and verifies that the WildFly OpenSSL testsuite passes with this built native.

Sample CI run can be seen here:
https://github.com/fjuma/wildfly-openssl-natives/actions/runs/3753152810