### PR TITLE
Add loongarch64 support

### DIFF
--- a/linux-loongarch64/Makefile
+++ b/linux-loongarch64/Makefile
@@ -1,0 +1,17 @@
+CC = cc
+SRC = alpn.c clientcert.c options.c session.c ssl.c threads.c util.c
+OBJ = $(patsubst %.c, target/%.o, $(SRC))
+
+default: target/classes/linux-loongarch64/libwfssl.so
+
+clean:
+	rm -rf target
+
+target/classes/linux-loongarch64:
+	mkdir -p target/classes/linux-loongarch64
+
+target/%.o : ../libwfssl/src/%.c target/classes/linux-loongarch64
+	$(CC) $(CFLAGS) -Werror -Wall -Wmissing-prototypes -Wstrict-prototypes -Wmissing-declarations -Wpointer-arith -std=c89 -Wdeclaration-after-statement -Wformat -Wformat-security -Wunused -Wno-unknown-pragmas -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux
+
+target/classes/linux-loongarch64/libwfssl.so: $(OBJ)
+	$(CC) $(CFLAGS) -shared $(OBJ) -o $@ $(LDFLAGS) -Wl,--no-as-needed -ldl

--- a/linux-loongarch64/pom.xml
+++ b/linux-loongarch64/pom.xml
@@ -1,0 +1,82 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.openssl</groupId>
+        <artifactId>wildfly-openssl-natives-parent</artifactId>
+        <version>2.2.2.Final</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <groupId>org.wildfly.openssl</groupId>
+    <artifactId>wildfly-openssl-linux-loongarch64</artifactId>
+    <version>2.2.2.Final</version>
+
+    <packaging>jar</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <executable>make</executable>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <profiles>
+        <profile>
+            <id>parent-release</id>
+            <activation>
+                <property>
+                    <name>parent-release</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-deploy-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,18 @@
             </modules>
         </profile>
         <profile>
+            <id>linux-loongarch64</id>
+            <activation>
+                <os>
+                    <family>linux</family>
+                    <arch>loongarch64</arch>
+                </os>
+            </activation>
+            <modules>
+                <module>linux-loongarch64</module>
+            </modules>
+        </profile>
+        <profile>
             <id>linux-ppc64le</id>
             <activation>
                 <os>


### PR DESCRIPTION
LoongArch is a risc architecture, like RISCV. This PR is used to support LoongArch.